### PR TITLE
security: enforce ChromaDB RCE precondition invariant (CVE-2026-45829)

### DIFF
--- a/docs/audits/CVE-2026-45829_chromadb.md
+++ b/docs/audits/CVE-2026-45829_chromadb.md
@@ -1,0 +1,66 @@
+# CVE-2026-45829 — ChromaDB pre-auth RCE — exposure assessment
+
+- **Advisory:** GHSA-f4j7-r4q5-qw2c / CVE-2026-45829
+- **Severity:** Critical
+- **Affected:** `chromadb >= 1.0.0, <= 1.5.9`
+- **Patched version:** **None.** 1.5.9 is the latest release; no fix is available to upgrade to.
+- **Sanctuary's pinned version:** 1.5.9 (constraint `chromadb>=1.5.9` in `pyproject.toml`)
+- **Dependabot alert:** #90
+- **Assessed:** 2026-07-16 (Opus 4.8)
+
+## The vulnerability
+
+From the advisory:
+
+> A pre-authentication, code injection vulnerability in version 1.0.0 or later
+> of the ChromaDB Python project allows an unauthenticated attacker to run
+> arbitrary code on the server by sending a malicious model repository and
+> `trust_remote_code` set to true in the
+> `/api/v2/tenants/{tenant}/databases/{db}/collections` endpoint.
+
+The exploit requires **all three** of:
+1. A **running Chroma HTTP server** exposing the `/api/v2/.../collections` endpoint.
+2. **`trust_remote_code=true`** in the embedding configuration (the code-exec trigger).
+3. An **attacker-controlled model repository** to be loaded and executed.
+
+## Why Sanctuary is not exposed
+
+Sanctuary meets **none** of the three preconditions:
+
+| Precondition | Sanctuary | Evidence |
+|---|---|---|
+| Chroma **server** running | **No** — embedded only | Live memory uses `chromadb.PersistentClient` (`sanctuary/mind/memory/storage.py`, `sanctuary/mind/librarian.py`). Nothing launches a Chroma HTTP server. `infrastructure/remote_memory.py` is a *client* (`HttpClient`) and is **not wired into the runner**. |
+| `trust_remote_code=true` | **No** | The string does not appear anywhere in the codebase. |
+| Attacker-supplied model | **No** | The embedding model is hardcoded (`sentence-transformers/all-mpnet-base-v2`); no dynamic/remote model selection. |
+
+The vulnerability lives in ChromaDB's **server** code path. Embedded ChromaDB
+runs no network server, so there is no unauthenticated endpoint to reach —
+the attack has no surface here.
+
+## Stance: mitigate-and-monitor (no code change to the dependency)
+
+There is no upstream patch to apply, and patching the vendored library (a
+server path we don't use) would be fragile and pointless. Instead we **keep
+the preconditions unmet** and enforce that:
+
+1. **Enforced invariant (CI):** `sanctuary/tests/test_chromadb_rce_guard.py`
+   scans tracked source and fails loudly if `trust_remote_code` is ever
+   enabled — the decisive trigger. This protects against future drift
+   regardless of chromadb's server code.
+2. **Keep embedded-only.** Do not wire in `remote_memory.py` / a Chroma
+   server. If a server is ever genuinely needed, it must be bound to
+   localhost only, authenticated (the module already supports a bearer
+   token), and never fronted by an untrusted network — and only once a
+   patched chromadb release exists.
+3. **Monitor for a fix.** Watch for a `chromadb > 1.5.9` release that
+   addresses CVE-2026-45829, then bump and drop this mitigation. Dependabot
+   alert #90 tracks it.
+
+## Residual risk
+
+Low. The RCE is unreachable in the current architecture. The residual risk is
+**drift** — a future change enabling the server path and/or `trust_remote_code`
+— which the CI guard (item 1) is designed to catch. If `trust_remote_code` is
+ever legitimately required for a *trusted, vendored, offline* model, the guard
+test documents the escape pragma; using it must be recorded here with its
+justification.

--- a/sanctuary/tests/test_chromadb_rce_guard.py
+++ b/sanctuary/tests/test_chromadb_rce_guard.py
@@ -1,0 +1,137 @@
+"""Security invariant: keep Sanctuary outside the preconditions of the
+ChromaDB pre-auth RCE (CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c).
+
+The advisory: in chromadb >= 1.0.0 (through 1.5.9, the latest release —
+**no patched version exists**), an unauthenticated attacker can achieve
+remote code execution by POSTing a malicious model repository with
+``trust_remote_code`` set to true to the Chroma *server's*
+``/api/v2/.../collections`` endpoint. The dangerous model code is then
+executed during embedding.
+
+Sanctuary is not exposed, because it meets none of the three preconditions:
+
+1. **No Chroma server.** The live memory path uses embedded
+   ``chromadb.PersistentClient`` (in-process, local disk). Nothing launches
+   a Chroma HTTP server; ``infrastructure/remote_memory.py`` is only a
+   *client* and is not wired into the runner.
+2. **No ``trust_remote_code``.** The embedding trigger is never enabled.
+3. **No attacker-supplied model.** The embedding model is a hardcoded
+   sentence-transformers checkpoint, not a caller-controlled repo.
+
+Because there is no upstream fix to upgrade to, the mitigation is to *keep*
+this true. This test makes precondition (2) — the decisive, unambiguous
+trigger — a CI-enforced invariant: if anyone ever introduces
+``trust_remote_code=True`` (in an embedding config, a transformers/
+sentence-transformers load, or anywhere else), the RCE precondition is back
+and this test fails loudly, pointing at the CVE.
+
+If a future change legitimately requires ``trust_remote_code`` for a
+*trusted, vendored, offline* model, append ``# pragma: allow-trust-remote-code``
+to that line AND record the justification in
+``docs/audits/CVE-2026-45829_chromadb.md``. Do not silence this test by
+editing it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Matches trust_remote_code being set truthy in any of the forms it appears
+# across Python source and config: ``trust_remote_code=True``,
+# ``trust_remote_code = True``, ``"trust_remote_code": True``,
+# ``trust_remote_code: true`` (yaml/json).
+TRUST_REMOTE_CODE_TRUE = re.compile(
+    r"""trust_remote_code["']?\s*[:=]\s*(?:True|true|1)\b"""
+)
+
+ESCAPE_PRAGMA = "pragma: allow-trust-remote-code"
+
+SCAN_EXTENSIONS = {".py", ".pyi", ".toml", ".yaml", ".yml", ".json", ".cfg", ".ini"}
+
+SKIP_DIR_NAMES = {
+    ".git", ".venv", "venv", "env", "__pycache__", "node_modules",
+    ".pytest_cache", ".hypothesis", "build", "dist", ".mypy_cache",
+    ".ruff_cache", ".tox",
+}
+
+
+def _iter_source_files(root: Path):
+    """Yield tracked source files to scan (``git ls-files``), falling back to
+    a full walk if git is unavailable. Mirrors ``test_no_hardcoded_paths``."""
+    import subprocess
+
+    tracked = None
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        tracked = {
+            (root / line).resolve()
+            for line in result.stdout.splitlines()
+            if line.strip()
+        }
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        tracked = None
+
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in SCAN_EXTENSIONS:
+            continue
+        if any(part in SKIP_DIR_NAMES for part in path.parts):
+            continue
+        if path.name == "uv.lock":
+            continue
+        # Skip this test file itself — it names the pattern by definition.
+        if path.name == "test_chromadb_rce_guard.py":
+            continue
+        if tracked is not None and path.resolve() not in tracked:
+            continue
+        yield path
+
+
+def test_trust_remote_code_never_enabled():
+    """Fail loudly if any tracked source enables ``trust_remote_code``.
+
+    This is the decisive precondition of CVE-2026-45829 that Sanctuary
+    controls. Keeping it false keeps the RCE unreachable even though no
+    upstream chromadb patch exists.
+    """
+    findings: list[str] = []
+
+    for path in _iter_source_files(REPO_ROOT):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        for line_num, line in enumerate(text.splitlines(), start=1):
+            if ESCAPE_PRAGMA in line:
+                continue
+            if TRUST_REMOTE_CODE_TRUE.search(line):
+                rel = path.relative_to(REPO_ROOT)
+                findings.append(f"  {rel}:{line_num}: {line.strip()!r}")
+
+    if findings:
+        msg = (
+            "`trust_remote_code` is enabled somewhere in source. This is the "
+            "code-execution trigger of CVE-2026-45829 (ChromaDB pre-auth RCE, "
+            "no upstream fix). Enabling it — especially with a caller- or "
+            "network-supplied model — reintroduces the RCE precondition.\n\n"
+            "Use a trusted, vendored, hardcoded model without trust_remote_code. "
+            "If it is genuinely required for a trusted offline model, append "
+            f"`# {ESCAPE_PRAGMA}` to the line and document the justification in "
+            "docs/audits/CVE-2026-45829_chromadb.md.\n\n"
+            + "\n".join(findings)
+        )
+        pytest.fail(msg)


### PR DESCRIPTION
## Enforce the ChromaDB RCE precondition invariant (CVE-2026-45829)

Companion to #188. That PR clears 9 of 10 Dependabot alerts; this one addresses the 10th — the **critical**, `chromadb` #90 — which **has no upstream fix** (1.5.9 is the latest release).

### The finding
CVE-2026-45829 is a **pre-auth RCE in ChromaDB's *server*.** The exploit needs three conditions, and Sanctuary meets **none**:

| Precondition | Sanctuary | Why |
|---|---|---|
| Running Chroma **server** | ❌ | Embedded `PersistentClient` only; nothing launches a server. `remote_memory.py` (`HttpClient`) is a client and isn't wired in. |
| `trust_remote_code=true` | ❌ | Not present anywhere in the codebase. |
| Attacker-supplied model | ❌ | Hardcoded `sentence-transformers/all-mpnet-base-v2`. |

So the RCE is **unreachable** in the current architecture. The residual risk is *drift* — a future change enabling the server path and/or `trust_remote_code`.

### The fix (an enforced invariant, not a dependency patch)
There's nothing to upgrade to, and patching the unused server path in the vendored library would be fragile and pointless. Instead this keeps the safe config from drifting:

- **`sanctuary/tests/test_chromadb_rce_guard.py`** — CI-enforced source-scan (same idiom as `test_no_hardcoded_paths`) that **fails loud if `trust_remote_code` is ever enabled** — the decisive code-exec trigger. Includes an escape pragma for a documented trusted-offline exception. Regex verified against positive/negative cases.
- **`docs/audits/CVE-2026-45829_chromadb.md`** — full exposure assessment + mitigate-and-monitor stance (stay embedded-only; localhost+auth if a server is ever needed; bump when a patched chromadb ships).

Dependabot #90 stays open until upstream releases a fix; this documents why that's acceptable and guards against making it exploitable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
